### PR TITLE
Resolves a persistance problem when deleting blocks from panel

### DIFF
--- a/EventSubscriber/PanelEventSubscriber.php
+++ b/EventSubscriber/PanelEventSubscriber.php
@@ -5,6 +5,7 @@ namespace Umanit\BlockBundle\EventSubscriber;
 use \Doctrine\ORM;
 use \Doctrine\Common;
 use Umanit\BlockBundle\Entity\Panel;
+use Umanit\BlockBundle\Model\BlockInterface;
 use Umanit\BlockBundle\Resolver\BlockManagerResolver;
 use Doctrine\Common\Collections\Criteria;
 
@@ -87,6 +88,10 @@ class PanelEventSubscriber implements Common\EventSubscriber
     public function preUpdate(ORM\Event\LifecycleEventArgs $args)
     {
         $entity = $args->getEntity();
+
+        if ($entity instanceof BlockInterface) {
+            $entity = $entity->getPanel();
+        }
 
         if (!$entity instanceof Panel) {
             return;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,21 +1,25 @@
 services:
     umanit_block.resolver.block_manager_resolver:
         class: Umanit\BlockBundle\Resolver\BlockManagerResolver
+    Umanit\BlockBundle\Resolver\BlockManagerResolver: '@umanit_block.resolver.block_manager_resolver'
 
     umanit_block.twig.block_extension:
         class: Umanit\BlockBundle\Twig\BlockExtension
         arguments: ['@umanit_block.resolver.block_manager_resolver', '@logger', '%kernel.debug%']
         tags:
             - { name: twig.extension }
+    Umanit\BlockBundle\Twig\BlockExtension: '@umanit_block.twig.block_extension'
 
     umanit_block.event_listener.panel_event_subscriber:
         class: Umanit\BlockBundle\EventSubscriber\PanelEventSubscriber
         arguments: ['@umanit_block.resolver.block_manager_resolver']
         tags:
             - { name: doctrine.event_subscriber }
+    Umanit\BlockBundle\EventSubscriber\PanelEventSubscriber: '@umanit_block.event_listener.panel_event_subscriber'
 
     umanit_block.form.panel_type:
         class: Umanit\BlockBundle\Form\PanelType
         arguments: ['@umanit_block.resolver.block_manager_resolver', '@doctrine.orm.entity_manager', '@translator']
         tags:
             - { name: form.type, alias: Umanit\BlockBundle\Form\PanelType }
+    Umanit\BlockBundle\Form\PanelType: '@umanit_block.form.panel_type'


### PR DESCRIPTION
Issue: when trying to delete a block from an admin form, the block is not deleted on save.

In some conditions, the entity being updated is not the Panel, but an entity within it, implementing BlockInterface. In those cases, we use the Panel owning the entity to keep executing the code (removing the orphans).